### PR TITLE
Travis CI modifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ phpunit.xml
 vendor/
 build/
 .php_cs
+/git-review.yml
 
 # OS Generated Files #
 ######################

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ vendor/
 build/
 .php_cs
 /git-review.yml
+phpcs.xml
 
 # OS Generated Files #
 ######################

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.0
   - 7.1
+  - 7.2
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,7 @@ before_script:
 script:
   - vendor/bin/phpcs --colors --standard=PSR2 src/ bin/ hooks/ tests/
   - php vendor/bin/phpunit --coverage-text
-  - CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB "${TRAVIS_COMMIT_RANGE}")
-  - if ! echo "${CHANGED_FILES}" | grep -qE "^(\\.php_cs(\\.dist)?|composer\\.lock)$"; then IFS=$'\n' EXTRA_ARGS=('--path-mode=intersection' '--' ${CHANGED_FILES[@]}); fi
-  - vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --using-cache=no "${EXTRA_ARGS[@]}"
+  - bin/git-review tools:php-cs-fixer
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
   - php vendor/bin/phpunit --coverage-text
   - CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB "${TRAVIS_COMMIT_RANGE}")
   - if ! echo "${CHANGED_FILES}" | grep -qE "^(\\.php_cs(\\.dist)?|composer\\.lock)$"; then IFS=$'\n' EXTRA_ARGS=('--path-mode=intersection' '--' ${CHANGED_FILES[@]}); fi
-  - vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no "${EXTRA_ARGS[@]}"
+  - vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --using-cache=no "${EXTRA_ARGS[@]}"
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
   - composer install --prefer-source --no-interaction --dev
 
 script:
-  - vendor/bin/phpcs --colors --standard=PSR2 src/ bin/ hooks/ tests/
+  - vendor/bin/phpcs
   - php vendor/bin/phpunit --coverage-text
   - bin/git-review tools:php-cs-fixer
 

--- a/bin/git-review.php
+++ b/bin/git-review.php
@@ -36,6 +36,7 @@ if (!$included) {
 use GitReview\Command\HookInstallCommand;
 use GitReview\Command\HookListCommand;
 use GitReview\Command\HookRunCommand;
+use GitReview\Command\PhpCsFixerCommand;
 use Symfony\Component\Console\Application;
 
 $name    = 'GitReview Command Line Tool';
@@ -47,6 +48,7 @@ $console->addCommands([
     new HookListCommand(),
     new HookInstallCommand(),
     new HookRunCommand(),
+    new PhpCsFixerCommand(),
 ]);
 
 $console->run();

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
         "league/climate": "^2.0 || ^3.0",
         "symfony/console": "^2.0 || ^3.2",
         "symfony/process": "^2.1 || ^3.1",
-        "tightenco/collect": "^5.5 || ^5.6"
+        "tightenco/collect": "^5.5 || ^5.6",
+        "danielstjules/stringy": "~3.1.0"
     },
     "require-dev": {
         "mockery/mockery": "^0.9",

--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,10 @@
             "vendor/bin/phpcs --colors --standard=PSR2 src/ bin/ hooks/ tests/",
             "vendor/bin/phpunit --color=always --testsuite unit",
             "vendor/bin/phpunit --color=always --testsuite functional"
+        ],
+        "code-style": [
+            "php vendor/bin/phpcs",
+            "bin/git-review tools:php-cs-fixer"
         ]
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         "symfony/console": "^2.0 || ^3.2",
         "symfony/process": "^2.1 || ^3.1",
         "tightenco/collect": "^5.5 || ^5.6",
-        "danielstjules/stringy": "~3.1.0"
+        "danielstjules/stringy": "~3.1.0",
+        "spatie/regex": "^1.2"
     },
     "require-dev": {
         "mockery/mockery": "^0.9",

--- a/git-review.yml.dist
+++ b/git-review.yml.dist
@@ -1,0 +1,17 @@
+---
+
+tools:
+  php_cs_fixer:
+    bin_path: "vendor/bin/php-cs-fixer"
+    config_path: "./.php_cs.dist"
+    verbose: true
+    dry_run: true
+    stop_on_violation: false
+    use_cache: false
+    allow_risky: false
+    paths_to_scan:
+      - "bin/*"
+      - "hooks/*"
+      - "src/*"
+      - "tests/*"
+      - ".php_cs.dist"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<ruleset name="GitReview">
+    <description>The coding standard for Git Review</description>
+
+    <file>./bin</file>
+    <file>./src</file>
+    <file>./hooks</file>
+    <file>./tests</file>
+
+    <arg name="colors"/>
+
+    <rule ref="PSR1"/>
+    <rule ref="PSR2"/>
+</ruleset>

--- a/src/Command/PhpCsFixerCommand.php
+++ b/src/Command/PhpCsFixerCommand.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace GitReview\Command;
+
+use GitReview\File\File;
+use GitReview\File\FilesFinder;
+use GitReview\VersionControl\GitBranch;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+use Tightenco\Collect\Support\Collection;
+
+class PhpCsFixerCommand extends Command
+{
+    const CONFIG_PATH = 'yml-config-path';
+    private $useCache = false;
+    private $verbose = false;
+    private $allowRisky = false;
+    private $dryRun = false;
+
+    protected function configure()
+    {
+        $this->setName('tools:php-cs-fixer');
+
+        $this->setDescription('Run Php-CS-Fixer on only the changed files on a Git branch.');
+
+        $this->addArgument(
+            self::CONFIG_PATH,
+            InputArgument::OPTIONAL,
+            'The path to the git-review configuration file, named `git-review.yml(.dist)`'
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+        $currentWorkingDirectory = getcwd();
+
+        $io->note("Current working directory: $currentWorkingDirectory");
+
+        $configPath = $this->getYamlConfigurationFilePath(
+            $currentWorkingDirectory,
+            $input->getArgument(self::CONFIG_PATH)
+        );
+
+        if (!$configPath) {
+            $io->error(
+                "Configuration not found! Please ensure you setup the config file and run this command in the "
+                ."appropriate root of your project"
+            );
+            exit(1);
+        }
+
+        $io->note("Using configuration file: $configPath");
+
+        $branch = new GitBranch($currentWorkingDirectory);
+
+        try {
+            $config = Yaml::parse(file_get_contents($configPath));
+        } catch (ParseException $exception) {
+            $io->error('Unable to parse the YAML string: %s', $exception->getMessage());
+
+            exit(1);
+        }
+
+        $phpCsFixerConfig = $config["tools"]["php_cs_fixer"];
+
+        $io->title('Retrieving changed files on branch using the following filters:');
+        $io->listing($phpCsFixerConfig["paths_to_scan"]);
+        /** @var Collection $changedFiles */
+        $changedFiles = $branch->getChangedFiles();
+
+        $filesFinder = new FilesFinder($changedFiles, $phpCsFixerConfig["paths_to_scan"]);
+
+        if ($filesFinder->count() == 0) {
+            $io->success("No files to scan");
+            exit(0);
+        }
+
+        $output->writeln("<options=bold,underscore>Found files...</>\n");
+
+        $filePaths = $filesFinder->getFoundFiles()
+            ->sortBy(function (File $file) {
+                return $file->getRelativePath();
+            })
+            ->reject(function (File $file) {
+                return !file_exists($file->getRelativePath());
+            })
+            ->map(function (File $file) {
+                return $file->getRelativePath();
+            })
+            ->unique()
+            ->reduce(function (string $paths, string $file) use ($io) {
+                $io->writeln("<info>{$file}</info>");
+
+                if ($paths === '') {
+                    return $paths = $file;
+                }
+
+                return $paths .= " {$file}";
+            }, '');
+
+        $command = $this->getCommand($phpCsFixerConfig, $filePaths, $branch->getName());
+
+        $output->writeln("\n<options=bold,underscore>Running command:</>\n");
+        $io->writeln("<info>$command</info>\n");
+        $process = new \Symfony\Component\Process\Process($command);
+        $process->start();
+
+        $iterator = $process->getIterator($process::ITER_KEEP_OUTPUT);
+
+        foreach ($iterator as $data) {
+            echo $data;
+        }
+
+        if ($process->getExitCode() !== 0) {
+            $io->writeln("\n<error>Php-CS-Fixer failed. Locally, you should run:</error>\n");
+
+            $io->writeln(
+                "<fg=red>php vendor/bin/php-cs-fixer fix {$filePaths} --config=.php_cs.dist -v</>"
+            );
+
+            exit($process->getExitCode());
+        }
+
+        $io->newLine();
+
+        return $io->success("Php-CS-Fixer passed, good job!!!!");
+    }
+
+    protected function getYamlConfigurationFilePath(string $currentWorkingDirectory, string $configPath = null): string
+    {
+        if ($configPath) {
+            return $configPath;
+        }
+
+        $finder = new Finder();
+        $iterator = $finder
+            ->files()
+            ->name('git-review.yml.dist')
+            ->name('git-review.yml')
+            ->depth(0)
+            ->in($currentWorkingDirectory);
+
+        return (new Collection($iterator))
+            ->mapWithKeys(function (\Symfony\Component\Finder\SplFileInfo $fileInfo) {
+                return [$fileInfo->getFileName() => $fileInfo->getRealPath()];
+            })
+            ->sort()
+            ->first(function ($item, $key) {
+                return $key === 'git-review.yml' || $key === 'git-review.yml.dist';
+            });
+    }
+
+    protected function getCommand(array $phpCsFixerConfig, string $filePaths, string $branchName): string
+    {
+        $phpCsFixerBin = $phpCsFixerConfig["bin_path"] ?? "vendor/bin/php-cs-fixer";
+        $phpCsFixerConfigPath = $phpCsFixerConfig["config_path"] ?? ".php_cs.dist";
+
+        $cmd = "php {$phpCsFixerBin} fix";
+
+        if ($branchName !== 'master') {
+            $cmd .= " {$filePaths}";
+        }
+
+        $cmd .= " --config={$phpCsFixerConfigPath}";
+
+        if (isset($phpCsFixerConfig["verbose"]) && $phpCsFixerConfig["verbose"]) {
+            $cmd .= " -v";
+            $this->verbose = true;
+        }
+
+        if (isset($phpCsFixerConfig["dry_run"]) && $phpCsFixerConfig["dry_run"]) {
+            $cmd .= " --dry-run";
+            $this->dryRun = true;
+        }
+
+        if (isset($phpCsFixerConfig["use_cache"]) && $phpCsFixerConfig["use_cache"]) {
+            $this->useCache = true;
+        }
+
+        $cmd .= ' --using-cache=' . (($this->useCache) ? 'yes' : 'no');
+
+        return $cmd;
+    }
+}

--- a/src/File/FilesFinder.php
+++ b/src/File/FilesFinder.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace GitReview\File;
+
+use Spatie\Regex\Regex;
+use Tightenco\Collect\Support\Collection;
+
+class FilesFinder
+{
+    private $files;
+    private $pathCriteria;
+    /** @var Collection $foundFiles */
+    private $foundFiles;
+
+    public function __construct(Collection $files, array $pathCriteria = [])
+    {
+        $this->files = $files;
+        $this->pathCriteria = $pathCriteria;
+        $this->foundFiles = new Collection([]);
+
+        $this->formatCriteria();
+
+        $this->findFilesByGivenCriteria();
+    }
+
+    public function getFoundFiles(): Collection
+    {
+        return $this->foundFiles;
+    }
+
+    public function count(): int
+    {
+        return count($this->getFoundFiles());
+    }
+
+    private function findFilesByGivenCriteria()
+    {
+        $this->files->filter(function (File $file) {
+            $found = false;
+
+            foreach ($this->pathCriteria as $criteria) {
+                if (Regex::match($criteria, $file->getRelativePath())->hasMatch()) {
+                    $found = true;
+
+                    break;
+                }
+            }
+
+            return $found;
+        })->each(function (File $file) {
+            $this->addFile($file);
+        });
+    }
+
+    private function addFile($file)
+    {
+        $this->foundFiles->push($file);
+    }
+
+    private function formatCriteria()
+    {
+        $this->pathCriteria = \array_map(function ($value) {
+            $escapeChars = str_replace("/*", "/.*", $value);
+            $escapeChars = str_replace("/", "\/", $escapeChars);
+
+            return "/$escapeChars/";
+        }, $this->pathCriteria);
+    }
+}

--- a/src/VersionControl/GitBranch.php
+++ b/src/VersionControl/GitBranch.php
@@ -42,14 +42,6 @@ class GitBranch implements GitBranchInterface
 
         $fileCollection->addFiles(\array_filter(\explode("\n", $committedFilesProcess->getOutput())));
 
-        if ($this->isDirty()) {
-            $files = $this->processFactory->create("git status --short | sort | uniq")->getOutput();
-
-            if (strlen($files) > 0) {
-                $fileCollection->addFiles(\array_filter(\explode("\n", $files)));
-            }
-        }
-
         return $fileCollection->getFileCollection();
     }
 

--- a/tests/unit/File/FilesFinderTest.php
+++ b/tests/unit/File/FilesFinderTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace GitReview\Test\Unit\Classes;
+
+use GitReview\File\File;
+use GitReview\File\FilesFinder;
+use PHPUnit_Framework_TestCase as TestCase;
+use Tightenco\Collect\Support\Collection;
+
+class FilesFinderTest extends TestCase
+{
+    public function testGetFileCount()
+    {
+        $files = new Collection([
+            new File('A', 'a/b/c.txt', '/tmp/repo-base'),
+            new File('A', 'c/b/a.txt', '/tmp/repo-base'),
+        ]);
+
+        $foundFiles = new FilesFinder($files, ["a/b/c.txt"]);
+
+        $this->assertEquals(1, $foundFiles->count());
+    }
+
+    public function testGetFoundFilesCanAccommodateWildcardDirectorySearch()
+    {
+        $files = new Collection([
+            new File('A', 'example/test1/subfolder/file.txt', '/tmp/repo-base'),
+            new File('A', 'example/test2/subfolder/test.js', '/tmp/repo-base'),
+            new File('A', 'example/test2/subfolder/anotherlevel/test.php', '/tmp/repo-base'),
+            new File('A', 'example/test3/legacy/file.txt', '/tmp/repo-base'),
+            new File('A', 'example/test2/file.txt', '/tmp/repo-base'),
+            new File('A', 'example2/another-file.txt', '/tmp/repo-base'),
+            new File('A', '.php_cs.dist', '/tmp/repo-base'),
+            new File('A', '.php_cs', '/tmp/repo-base'),
+        ]);
+
+        $foundFiles = new FilesFinder($files, [
+            'example/*/subfolder',
+            'example2/*',
+            '.php_cs',
+            '.php_cs.dist',
+        ]);
+
+        $this->assertEquals(6, $foundFiles->count());
+
+        $this->assertEquals([
+            'example/test1/subfolder/file.txt',
+            'example/test2/subfolder/test.js',
+            'example/test2/subfolder/anotherlevel/test.php',
+            'example2/another-file.txt',
+            '.php_cs.dist',
+            '.php_cs',
+        ], $foundFiles->getFoundFiles()->map(function (File $file) {
+            return $file->getRelativePath();
+        })->toArray());
+    }
+}


### PR DESCRIPTION
This includes:

- Adding a new bin file that runs `php-cs-fixer` against changed files on a branch
- Add support for PHP7.2 as part of CI testing
- Do not run `php-cs-fixer` on `stop-on-violation` mode