### PR TITLE
Console: do not exit `tools:php-cs-fixer` command when there are no changed files

### DIFF
--- a/src/Command/PhpCsFixerCommand.php
+++ b/src/Command/PhpCsFixerCommand.php
@@ -77,11 +77,6 @@ class PhpCsFixerCommand extends Command
 
         $filesFinder = new FilesFinder($changedFiles, $phpCsFixerConfig["paths_to_scan"]);
 
-        if ($filesFinder->count() == 0) {
-            $io->success("No files to scan");
-            exit(0);
-        }
-
         $output->writeln("<options=bold,underscore>Found files...</>\n");
 
         $filePaths = $filesFinder->getFoundFiles()


### PR DESCRIPTION
This means the process will exit when running on `master` and we don't want that.

Example:

https://travis-ci.org/mcampbell508/git-review/jobs/355083875