### PR TITLE
PHPStan: Add configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
 
 script:
   - vendor/bin/phpcs
-  - php vendor/bin/phpstan analyse app bin hooks src tests .php_cs.dist
+  - php vendor/bin/phpstan analyse app bin hooks src tests .php_cs.dist -c phpstan.neon -l 0
   - php vendor/bin/parallel-lint app bin hooks src tests .php_cs.dist
   - php vendor/bin/phpunit --coverage-text
   - bin/git-review tools:php-cs-fixer

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,4 @@
 parameters:
     ignoreErrors:
         - '#Mockery\\MockInterface::shouldReceive\(\)#'
+    reportUnmatchedIgnoredErrors: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,3 @@
+parameters:
+    ignoreErrors:
+        - '#Mockery\\MockInterface::shouldReceive\(\)#'


### PR DESCRIPTION
This is so that we can ignore some errors to do with Mockery that are unexpected:

- https://github.com/phpstan/phpstan/issues/441
- https://github.com/phpstan/phpstan/issues/134

This will be useful, when we start using higher levels for PHPStan