### PR TITLE
Code Style improvements

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -74,6 +74,10 @@ $rules = [
     'ordered_imports' => true,
     'php_unit_construct' => true,
     'php_unit_dedicate_assert' => true,
+    'php_unit_test_annotation' => [
+        'case' => 'snake',
+        'style' => 'annotation',
+    ],
     'phpdoc_no_empty_return' => true,
     'phpdoc_no_package' => true,
     'phpdoc_scalar' => true,

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -13,6 +13,10 @@
         <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>
 
+    <rule ref="PSR1.Methods.CamelCapsMethodName">
+        <exclude-pattern>*/tests/*</exclude-pattern>
+    </rule>
+
     <rule ref="PSR1"/>
     <rule ref="PSR2"/>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,6 +9,10 @@
 
     <arg name="colors"/>
 
+    <rule ref="Generic.Files.LineLength">
+        <exclude-pattern>*/tests/*</exclude-pattern>
+    </rule>
+
     <rule ref="PSR1"/>
     <rule ref="PSR2"/>
 </ruleset>

--- a/tests/functional/VersionControl/GitBranchTest.php
+++ b/tests/functional/VersionControl/GitBranchTest.php
@@ -34,7 +34,10 @@ EOT;
         $this->assertFalse($this->gitBranch->isDirty());
     }
 
-    public function testItCanRetrieveBranchName(): void
+    /**
+     * @test
+     */
+    public function it_can_retrieve_branch_name(): void
     {
         $branchName = $this->gitBranch->getName();
 
@@ -47,7 +50,10 @@ EOT;
         $this->assertEquals($this->topicBranchName, $branchName);
     }
 
-    public function testItCanSeeIfBranchIsDirty(): void
+    /**
+     * @test
+     */
+    public function it_can_see_if_branch_is_dirty(): void
     {
         $this->runProcess("touch modified-file.txt");
 
@@ -58,7 +64,10 @@ EOT;
         $this->assertFalse($this->gitBranch->isDirty());
     }
 
-    public function testItCanGetParentHashAtPointerToMaster(): void
+    /**
+     * @test
+     */
+    public function it_can_get_parent_hash_at_pointer_to_master(): void
     {
         $masterCommitId = \trim($this->runProcess("git log --grep='master commit a' --format='%H'")->getOutput());
 
@@ -67,7 +76,10 @@ EOT;
         $this->assertEquals($masterCommitId, $this->gitBranch->getParentHash());
     }
 
-    public function testItCanGetAllChangedFilesOnBranchIncludingUncommitted(): void
+    /**
+     * @test
+     */
+    public function it_can_get_all_changed_files_on_branch_including_uncommitted(): void
     {
         $this->checkoutBranch($this->topicBranchName);
 

--- a/tests/functional/VersionControl/GitVersionControlTest.php
+++ b/tests/functional/VersionControl/GitVersionControlTest.php
@@ -35,7 +35,10 @@ class GitVersionControlTest extends FunctionalTestCase
         $this->runProcess('rm -rf ' . $this->directory);
     }
 
-    public function testGetStagedFilesWithNoGitRepo(): void
+    /**
+     * @test
+     */
+    public function get_staged_files_with_no_git_repo(): void
     {
         $collection = $this->gitVersionControl->getStagedFiles();
 
@@ -43,7 +46,10 @@ class GitVersionControlTest extends FunctionalTestCase
         $this->assertCount(0, $collection);
     }
 
-    public function testGetStagedFilesWithGitRepo(): void
+    /**
+     * @test
+     */
+    public function get_staged_files_with_git_repo_saassa_saassa(): void
     {
         $cmd = 'touch ' . $this->testFileName;
         $cmd .= ' && git init';
@@ -56,7 +62,10 @@ class GitVersionControlTest extends FunctionalTestCase
         $this->assertCount(0, $collection);
     }
 
-    public function testGetStagedFilesWithNewFile(): void
+    /**
+     * @test
+     */
+    public function get_staged_files_with_new_file(): void
     {
         $cmd = 'touch ' . $this->testFileName;
         $cmd .= ' && git init';
@@ -75,7 +84,10 @@ class GitVersionControlTest extends FunctionalTestCase
         $this->assertSame('A', $file->getStatus());
     }
 
-    public function testGetStagedFilesWithModifiedFile(): void
+    /**
+     * @test
+     */
+    public function get_staged_files_with_modified_file(): void
     {
         $cmd = 'touch ' . $this->testFileName;
         $cmd .= ' && git init';
@@ -97,7 +109,10 @@ class GitVersionControlTest extends FunctionalTestCase
         $this->assertSame('M', $file->getStatus());
     }
 
-    public function testGetStagedFilesWithPartiallyStagedFile(): void
+    /**
+     * @test
+     */
+    public function get_staged_files_with_partially_staged_file(): void
     {
         $cmd = 'touch ' . $this->testFileName;
         $cmd .= ' && git init';
@@ -124,7 +139,10 @@ class GitVersionControlTest extends FunctionalTestCase
         $this->assertSame('test', \trim($process->getOutput()));
     }
 
-    public function testGetStagedFilesWithMovedUnrenamedFile(): void
+    /**
+     * @test
+     */
+    public function get_staged_files_with_moved_unrenamed_file(): void
     {
         $testFolderName = 'test_folder';
 
@@ -153,7 +171,10 @@ class GitVersionControlTest extends FunctionalTestCase
         $this->assertStringStartsWith('R', $file->getStatus());
     }
 
-    public function testGetStagedFilesWithMovedRenamedFile(): void
+    /**
+     * @test
+     */
+    public function get_staged_files_with_moved_renamed_file(): void
     {
         $testFolderName = 'test_folder';
         $newTestFileName = 'test_new.txt';

--- a/tests/unit/Collection/CollectionTest.php
+++ b/tests/unit/Collection/CollectionTest.php
@@ -35,7 +35,10 @@ class CollectionTest extends TestCase
         Mockery::close();
     }
 
-    public function testConstructorWithArgument(): void
+    /**
+     * @test
+     */
+    public function constructor_with_argument(): void
     {
         $items = [
             Mockery::mock(IssueInterface::class),
@@ -56,7 +59,10 @@ class CollectionTest extends TestCase
         $this->assertCount(3, $this->collection);
     }
 
-    public function testConstructorWithoutArgument(): void
+    /**
+     * @test
+     */
+    public function constructor_without_argument(): void
     {
         $this->collection->shouldReceive('validate')->never()->andReturn(true);
 
@@ -65,7 +71,10 @@ class CollectionTest extends TestCase
         $this->assertCount(0, $this->collection);
     }
 
-    public function testAppendWithValidItem(): void
+    /**
+     * @test
+     */
+    public function append_with_valid_item(): void
     {
         $this->collection->shouldReceive('validate')->twice()->andReturn(true);
 
@@ -81,7 +90,10 @@ class CollectionTest extends TestCase
         $this->assertSame($mock, $this->collection->next());
     }
 
-    public function testAppendWithNotTrueOnValidate(): void
+    /**
+     * @test
+     */
+    public function append_with_not_true_on_validate(): void
     {
         $this->collection->shouldReceive('validate')->once()->andReturn(false);
         $mock = Mockery::mock(IssueInterface::class);
@@ -93,8 +105,10 @@ class CollectionTest extends TestCase
 
     /**
      * @expectedException InvalidArgumentException
+     *
+     * @test
      */
-    public function testAppendWithExceptionOnValidate(): void
+    public function append_with_exception_on_validate(): void
     {
         $this->collection->shouldReceive('validate')->once()->andThrow(new \InvalidArgumentException());
         $mock = Mockery::mock(IssueInterface::class);
@@ -104,7 +118,10 @@ class CollectionTest extends TestCase
         $this->assertCount(0, $this->collection);
     }
 
-    public function testToString(): void
+    /**
+     * @test
+     */
+    public function to_string(): void
     {
         $this->collection->shouldReceive('validate')->twice()->andReturn(true);
         $mock = Mockery::mock(IssueInterface::class);

--- a/tests/unit/Collection/FileCollectionTest.php
+++ b/tests/unit/Collection/FileCollectionTest.php
@@ -26,7 +26,10 @@ class FileCollectionTest extends TestCase
         $this->collection = new FileCollection();
     }
 
-    public function testValidateWithValidObject(): void
+    /**
+     * @test
+     */
+    public function validate_with_valid_object(): void
     {
         $object = Mockery::mock('GitReview\File\FileInterface');
 
@@ -35,15 +38,20 @@ class FileCollectionTest extends TestCase
 
     /**
      * @expectedException InvalidArgumentException
+     *
+     * @test
      */
-    public function testValidateWithInvalidObject(): void
+    public function validate_with_invalid_object(): void
     {
         $object = 'Test';
 
         $this->collection->validate($object);
     }
 
-    public function testSelectWithTrueCallback(): void
+    /**
+     * @test
+     */
+    public function select_with_true_callback(): void
     {
         $file = Mockery::mock('GitReview\File\FileInterface');
 
@@ -58,7 +66,10 @@ class FileCollectionTest extends TestCase
         $this->assertCount(1, $files);
     }
 
-    public function testSelectWithFalseCallback(): void
+    /**
+     * @test
+     */
+    public function select_with_false_callback(): void
     {
         $file = Mockery::mock('GitReview\File\FileInterface');
 
@@ -73,7 +84,10 @@ class FileCollectionTest extends TestCase
         $this->assertCount(0, $files);
     }
 
-    public function testSelectWithEmptyCollection(): void
+    /**
+     * @test
+     */
+    public function select_with_empty_collection(): void
     {
         $filter = function () {
             return true;

--- a/tests/unit/Collection/IssueCollectionTest.php
+++ b/tests/unit/Collection/IssueCollectionTest.php
@@ -27,7 +27,10 @@ class IssueCollectionTest extends TestCase
         $this->collection = new IssueCollection();
     }
 
-    public function testValidateWithValidObject(): void
+    /**
+     * @test
+     */
+    public function validate_with_valid_object(): void
     {
         $object = Mockery::mock('GitReview\Issue\IssueInterface');
 
@@ -36,15 +39,20 @@ class IssueCollectionTest extends TestCase
 
     /**
      * @expectedException InvalidArgumentException
+     *
+     * @test
      */
-    public function testValidateWithInvalidObject(): void
+    public function validate_with_invalid_object(): void
     {
         $object = 'Test';
 
         $this->collection->validate($object);
     }
 
-    public function testSelectWithTrueCallback(): void
+    /**
+     * @test
+     */
+    public function select_with_true_callback(): void
     {
         $issue = Mockery::mock('GitReview\Issue\IssueInterface');
 
@@ -59,7 +67,10 @@ class IssueCollectionTest extends TestCase
         $this->assertCount(1, $issues);
     }
 
-    public function testSelectWithFalseCallback(): void
+    /**
+     * @test
+     */
+    public function select_with_false_callback(): void
     {
         $issue = Mockery::mock('GitReview\Issue\IssueInterface');
 
@@ -74,7 +85,10 @@ class IssueCollectionTest extends TestCase
         $this->assertCount(0, $issues);
     }
 
-    public function testSelectWithEmptyCollection(): void
+    /**
+     * @test
+     */
+    public function select_with_empty_collection(): void
     {
         $filter = function () {
             return true;
@@ -83,7 +97,10 @@ class IssueCollectionTest extends TestCase
         $this->assertEquals(new IssueCollection(), $this->collection->select($filter));
     }
 
-    public function testForLevelWithMatchingLevel(): void
+    /**
+     * @test
+     */
+    public function for_level_with_matching_level(): void
     {
         $issue = Mockery::mock('GitReview\Issue\IssueInterface');
         $issue->shouldReceive('matches')->once()->andReturn(true);
@@ -96,7 +113,10 @@ class IssueCollectionTest extends TestCase
         $this->assertSame($issue, $issues->current());
     }
 
-    public function testForLevelWithNonMatchingLevel(): void
+    /**
+     * @test
+     */
+    public function for_level_with_non_matching_level(): void
     {
         $issue = Mockery::mock('GitReview\Issue\IssueInterface');
         $issue->shouldReceive('matches')->once()->andReturn(false);

--- a/tests/unit/Collection/ReviewCollectionTest.php
+++ b/tests/unit/Collection/ReviewCollectionTest.php
@@ -26,7 +26,10 @@ class ReviewCollectionTest extends TestCase
         $this->collection = new ReviewCollection();
     }
 
-    public function testValidateWithValidObject(): void
+    /**
+     * @test
+     */
+    public function validate_with_valid_object(): void
     {
         $object = Mockery::mock('GitReview\Review\ReviewInterface');
 
@@ -35,15 +38,20 @@ class ReviewCollectionTest extends TestCase
 
     /**
      * @expectedException InvalidArgumentException
+     *
+     * @test
      */
-    public function testValidateWithInvalidObject(): void
+    public function validate_with_invalid_object(): void
     {
         $object = 'Test';
 
         $this->collection->validate($object);
     }
 
-    public function testSelectWithTrueCallback(): void
+    /**
+     * @test
+     */
+    public function select_with_true_callback(): void
     {
         $review = Mockery::mock('GitReview\Review\ReviewInterface');
 
@@ -58,7 +66,10 @@ class ReviewCollectionTest extends TestCase
         $this->assertCount(1, $reviews);
     }
 
-    public function testSelectWithFalseCallback(): void
+    /**
+     * @test
+     */
+    public function select_with_false_callback(): void
     {
         $review = Mockery::mock('GitReview\Review\ReviewInterface');
 
@@ -73,7 +84,10 @@ class ReviewCollectionTest extends TestCase
         $this->assertCount(0, $reviews);
     }
 
-    public function testSelectWithEmptyCollection(): void
+    /**
+     * @test
+     */
+    public function select_with_empty_collection(): void
     {
         $filter = function () {
             return true;
@@ -82,7 +96,10 @@ class ReviewCollectionTest extends TestCase
         $this->assertEquals(new ReviewCollection(), $this->collection->select($filter));
     }
 
-    public function testForFileWithMatchingFile(): void
+    /**
+     * @test
+     */
+    public function for_file_with_matching_file(): void
     {
         $review = Mockery::mock('GitReview\Review\ReviewInterface');
         $review->shouldReceive('canReview')->once()->andReturn(true);
@@ -97,7 +114,10 @@ class ReviewCollectionTest extends TestCase
         $this->assertSame($review, $reviews->current());
     }
 
-    public function testForFileWithNonMatchingFile(): void
+    /**
+     * @test
+     */
+    public function for_file_with_non_matching_file(): void
     {
         $review = Mockery::mock('GitReview\Review\ReviewInterface');
         $review->shouldReceive('canReview')->once()->andReturn(false);

--- a/tests/unit/Commit/CommitMessageTest.php
+++ b/tests/unit/Commit/CommitMessageTest.php
@@ -28,7 +28,10 @@ class CommitMessageTest extends TestCase
         $this->fixtures = \realpath(__DIR__ . '/../../fixtures');
     }
 
-    public function testConstructionSubjectOnly(): void
+    /**
+     * @test
+     */
+    public function construction_subject_only(): void
     {
         $commit = new CommitMessage($this->message('subject-only'));
 
@@ -36,7 +39,10 @@ class CommitMessageTest extends TestCase
         $this->assertSame('', $commit->getBody());
     }
 
-    public function testConstructionSubjectAndBody(): void
+    /**
+     * @test
+     */
+    public function construction_subject_and_body(): void
     {
         $commit = new CommitMessage($this->message('subject-and-body'));
 
@@ -44,7 +50,10 @@ class CommitMessageTest extends TestCase
         $this->assertSame('We have the tools.', $commit->getBody());
     }
 
-    public function testConstructionSubjectAndBodyAndComments(): void
+    /**
+     * @test
+     */
+    public function construction_subject_and_body_and_comments(): void
     {
         $commit = new CommitMessage($this->message('subject-and-body-and-comments'));
 
@@ -53,7 +62,10 @@ class CommitMessageTest extends TestCase
         $this->assertSame('We have the tools.', $commit->getBody());
     }
 
-    public function testConstructionSubjectAndBodyAndDiff(): void
+    /**
+     * @test
+     */
+    public function construction_subject_and_body_and_diff(): void
     {
         $commit = new CommitMessage($this->message('subject-and-body-and-diff'));
 

--- a/tests/unit/File/FileTest.php
+++ b/tests/unit/File/FileTest.php
@@ -37,26 +37,38 @@ class FileTest extends TestCase
         $this->assertNotNull($this->file);
     }
 
-    public function testGetFileName(): void
+    /**
+     * @test
+     */
+    public function get_file_name(): void
     {
         $expected = \basename($this->filePath);
 
         $this->assertSame($expected, $this->file->getFileName());
     }
 
-    public function testGetRelativePath(): void
+    /**
+     * @test
+     */
+    public function get_relative_path(): void
     {
         $expected = \str_replace($this->projectPath . DIRECTORY_SEPARATOR, '', $this->filePath);
 
         $this->assertSame($expected, $this->file->getRelativePath());
     }
 
-    public function testGetFullPathWithNoCachedPath(): void
+    /**
+     * @test
+     */
+    public function get_full_path_with_no_cached_path(): void
     {
         $this->assertSame($this->filePath, $this->file->getFullPath());
     }
 
-    public function testGetFullPathWithCachedPath(): void
+    /**
+     * @test
+     */
+    public function get_full_path_with_cached_path(): void
     {
         $path = __FILE__;
 
@@ -65,7 +77,10 @@ class FileTest extends TestCase
         $this->assertSame($path, $this->file->getFullPath());
     }
 
-    public function testGetCachedPath(): void
+    /**
+     * @test
+     */
+    public function get_cached_path(): void
     {
         $this->assertNull($this->file->getCachedPath());
 
@@ -76,7 +91,10 @@ class FileTest extends TestCase
         $this->assertSame($path, $this->file->getCachedPath());
     }
 
-    public function testSetCachedPath(): void
+    /**
+     * @test
+     */
+    public function set_cached_path(): void
     {
         $this->assertNull($this->file->getCachedPath());
 
@@ -87,19 +105,28 @@ class FileTest extends TestCase
         $this->assertSame($path, $this->file->getCachedPath());
     }
 
-    public function testGetExtension(): void
+    /**
+     * @test
+     */
+    public function get_extension(): void
     {
         $expected = \pathinfo($this->filePath, PATHINFO_EXTENSION);
 
         $this->assertSame($expected, $this->file->getExtension());
     }
 
-    public function testGetStatus(): void
+    /**
+     * @test
+     */
+    public function get_status(): void
     {
         $this->assertSame($this->fileStatus, $this->file->getStatus());
     }
 
-    public function testGetFormattedStatus(): void
+    /**
+     * @test
+     */
+    public function get_formatted_status(): void
     {
         $statuses = ['A', 'C', 'M', 'R'];
 
@@ -111,15 +138,20 @@ class FileTest extends TestCase
 
     /**
      * @expectedException UnexpectedValueException
+     *
+     * @test
      */
-    public function testGetLevelNameWithInvalidInput(): void
+    public function get_level_name_with_invalid_input(): void
     {
         $file = new File('Z', $this->filePath, $this->projectPath);
 
         $this->assertInstanceOf('\UnexpectedValueException', $file->getFormattedStatus());
     }
 
-    public function testGetMimeType(): void
+    /**
+     * @test
+     */
+    public function get_mime_type(): void
     {
         $this->assertTrue(\mb_strpos($this->file->getMimeType(), 'php') !== false);
     }

--- a/tests/unit/File/FilesFinderTest.php
+++ b/tests/unit/File/FilesFinderTest.php
@@ -9,7 +9,10 @@ use Tightenco\Collect\Support\Collection;
 
 class FilesFinderTest extends TestCase
 {
-    public function testGetFileCount(): void
+    /**
+     * @test
+     */
+    public function get_file_count(): void
     {
         $files = new Collection([
             new File('A', 'a/b/c.txt', '/tmp/repo-base'),
@@ -21,7 +24,10 @@ class FilesFinderTest extends TestCase
         $this->assertEquals(1, $foundFiles->count());
     }
 
-    public function testGetFoundFilesCanAccommodateWildcardDirectorySearch(): void
+    /**
+     * @test
+     */
+    public function get_found_files_can_accommodate_wildcard_directory_search(): void
     {
         $files = new Collection([
             new File('A', 'example/test1/subfolder/file.txt', '/tmp/repo-base'),

--- a/tests/unit/GitReviewTest.php
+++ b/tests/unit/GitReviewTest.php
@@ -40,12 +40,18 @@ class GitReviewTest extends TestCase
         Mockery::close();
     }
 
-    public function testGetReporter(): void
+    /**
+     * @test
+     */
+    public function get_reporter(): void
     {
         $this->assertSame($this->reporter, $this->GitReview->getReporter());
     }
 
-    public function testSetReporter(): void
+    /**
+     * @test
+     */
+    public function set_reporter(): void
     {
         $newReporter = Mockery::mock('GitReview\Reporter\ReporterInterface');
 
@@ -54,7 +60,10 @@ class GitReviewTest extends TestCase
         $this->assertSame($newReporter, $this->GitReview->getReporter());
     }
 
-    public function testGetReviews(): void
+    /**
+     * @test
+     */
+    public function get_reviews(): void
     {
         $this->assertTrue($this->GitReview->getReviews() instanceof ReviewCollection);
         $this->assertCount(0, $this->GitReview->getReviews());
@@ -63,7 +72,10 @@ class GitReviewTest extends TestCase
         $this->assertCount(1, $this->GitReview->getReviews());
     }
 
-    public function testAddReview(): void
+    /**
+     * @test
+     */
+    public function add_review(): void
     {
         $this->assertCount(0, $this->GitReview->getReviews());
 
@@ -71,7 +83,10 @@ class GitReviewTest extends TestCase
         $this->assertCount(1, $this->GitReview->getReviews());
     }
 
-    public function testAddReviews(): void
+    /**
+     * @test
+     */
+    public function add_reviews(): void
     {
         $this->assertCount(0, $this->GitReview->getReviews());
 
@@ -81,7 +96,10 @@ class GitReviewTest extends TestCase
         $this->assertCount(2, $this->GitReview->getReviews());
     }
 
-    public function testReview(): void
+    /**
+     * @test
+     */
+    public function review(): void
     {
         $file = Mockery::mock('GitReview\File\FileInterface');
 

--- a/tests/unit/Issue/IssueTest.php
+++ b/tests/unit/Issue/IssueTest.php
@@ -51,17 +51,26 @@ class IssueTest extends TestCase
         Mockery::close();
     }
 
-    public function testGetLevel(): void
+    /**
+     * @test
+     */
+    public function get_level(): void
     {
         $this->assertSame($this->issueLevel, $this->issue->getLevel());
     }
 
-    public function testGetMessage(): void
+    /**
+     * @test
+     */
+    public function get_message(): void
     {
         $this->assertSame($this->issueMessage, $this->issue->getMessage());
     }
 
-    public function testGetReviewName(): void
+    /**
+     * @test
+     */
+    public function get_review_name(): void
     {
         // Mocked classes doesn't have a namespace so just expect the full class name.
         $expected = \get_class($this->issueReview);
@@ -69,7 +78,10 @@ class IssueTest extends TestCase
         $this->assertSame($expected, $this->issue->getReviewName());
     }
 
-    public function testGetReviewNameWithNamespace(): void
+    /**
+     * @test
+     */
+    public function get_review_name_with_namespace(): void
     {
         $review = new \GitReview\Review\General\NoCommitTagReview();
 
@@ -83,12 +95,18 @@ class IssueTest extends TestCase
         $this->assertSame('NoCommitTagReview', $issue->getReviewName());
     }
 
-    public function testGetSubject(): void
+    /**
+     * @test
+     */
+    public function get_subject(): void
     {
         $this->assertSame($this->issueFile, $this->issue->getSubject());
     }
 
-    public function testGetLevelName(): void
+    /**
+     * @test
+     */
+    public function get_level_name(): void
     {
         foreach ($this->levels as $level) {
             $issue = new Issue(
@@ -104,8 +122,10 @@ class IssueTest extends TestCase
 
     /**
      * @expectedException UnexpectedValueException
+     *
+     * @test
      */
-    public function testGetLevelNameWithInvalidInput(): void
+    public function get_level_name_with_invalid_input(): void
     {
         $issue = new Issue(
             Issue::LEVEL_ALL,
@@ -117,7 +137,10 @@ class IssueTest extends TestCase
         $this->assertNull($issue->getLevelName());
     }
 
-    public function testGetColour(): void
+    /**
+     * @test
+     */
+    public function get_colour(): void
     {
         foreach ($this->levels as $level) {
             $issue = new Issue(
@@ -133,8 +156,10 @@ class IssueTest extends TestCase
 
     /**
      * @expectedException UnexpectedValueException
+     *
+     * @test
      */
-    public function testGetColourWithInvalidInput(): void
+    public function get_colour_with_invalid_input(): void
     {
         $issue = Mockery::mock(
             'GitReview\Issue\Issue[getLevel]',
@@ -151,7 +176,10 @@ class IssueTest extends TestCase
         $this->assertNull($issue->getColour());
     }
 
-    public function testMatches(): void
+    /**
+     * @test
+     */
+    public function it_can_identify_matches(): void
     {
         $shouldMatch = [
             Issue::LEVEL_INFO,
@@ -176,7 +204,10 @@ class IssueTest extends TestCase
         }
     }
 
-    public function testToString(): void
+    /**
+     * @test
+     */
+    public function to_string(): void
     {
         $file = $this->issue->getSubject();
 

--- a/tests/unit/Process/ProcessFactoryTest.php
+++ b/tests/unit/Process/ProcessFactoryTest.php
@@ -8,7 +8,10 @@ use PHPUnit_Framework_TestCase as TestCase;
 
 class ProcessFactoryTest extends TestCase
 {
-    public function testItCanCreateProcessThroughFactory(): void
+    /**
+     * @test
+     */
+    public function it_can_create_process_through_factory(): void
     {
         $this->assertInstanceOf(ProcessInterface::class, (new ProcessFactory())->create('command'));
     }

--- a/tests/unit/Reporter/ReporterTest.php
+++ b/tests/unit/Reporter/ReporterTest.php
@@ -34,14 +34,20 @@ class ReporterTest extends TestCase
         $this->reporter = new Reporter();
     }
 
-    public function testReport(): void
+    /**
+     * @test
+     */
+    public function report(): void
     {
         $this->reporter->report(Issue::LEVEL_INFO, 'Test', $this->review, $this->file);
 
         $this->assertCount(1, $this->reporter->getIssues());
     }
 
-    public function testInfo(): void
+    /**
+     * @test
+     */
+    public function info(): void
     {
         $this->reporter->info('Test', $this->review, $this->file);
 
@@ -52,7 +58,10 @@ class ReporterTest extends TestCase
         $this->assertSame(Issue::LEVEL_INFO, $issues->current()->getLevel());
     }
 
-    public function testWarning(): void
+    /**
+     * @test
+     */
+    public function warning(): void
     {
         $this->reporter->warning('Test', $this->review, $this->file);
 
@@ -63,7 +72,10 @@ class ReporterTest extends TestCase
         $this->assertSame(Issue::LEVEL_WARNING, $issues->current()->getLevel());
     }
 
-    public function testError(): void
+    /**
+     * @test
+     */
+    public function error(): void
     {
         $this->reporter->error('Test', $this->review, $this->file);
 
@@ -74,19 +86,28 @@ class ReporterTest extends TestCase
         $this->assertSame(Issue::LEVEL_ERROR, $issues->current()->getLevel());
     }
 
-    public function testHasIssues(): void
+    /**
+     * @test
+     */
+    public function has_issues(): void
     {
         $this->reporter->info('Test', $this->review, $this->file);
 
         $this->assertTrue($this->reporter->hasIssues());
     }
 
-    public function testHasIssuesWithNoIssues(): void
+    /**
+     * @test
+     */
+    public function has_issues_with_no_issues(): void
     {
         $this->assertFalse($this->reporter->hasIssues());
     }
 
-    public function testGetIssues(): void
+    /**
+     * @test
+     */
+    public function get_issues(): void
     {
         $this->reporter->info('Test', $this->review, $this->file);
 

--- a/tests/unit/Review/AbstractReviewTest.php
+++ b/tests/unit/Review/AbstractReviewTest.php
@@ -18,7 +18,10 @@ use PHPUnit_Framework_TestCase as TestCase;
 
 class AbstractReviewTest extends TestCase
 {
-    public function testGetProcess(): void
+    /**
+     * @test
+     */
+    public function get_process(): void
     {
         $review = Mockery::mock('GitReview\Review\AbstractReview')->makePartial();
 
@@ -27,7 +30,10 @@ class AbstractReviewTest extends TestCase
         $this->assertInstanceOf('Symfony\Component\Process\Process', $process);
     }
 
-    public function testGetProcessWorkingDirectory(): void
+    /**
+     * @test
+     */
+    public function get_process_working_directory(): void
     {
         $review = Mockery::mock('GitReview\Review\AbstractReview')->makePartial();
 

--- a/tests/unit/Review/Composer/ComposerLintReviewTest.php
+++ b/tests/unit/Review/Composer/ComposerLintReviewTest.php
@@ -30,7 +30,10 @@ class ComposerLintReviewTest extends TestCase
         Mockery::close();
     }
 
-    public function testCanReview(): void
+    /**
+     * @test
+     */
+    public function can_review(): void
     {
         $composerFile = Mockery::mock('GitReview\File\FileInterface');
         $composerFile->shouldReceive('getFileName')->once()->andReturn('composer.json');
@@ -43,7 +46,10 @@ class ComposerLintReviewTest extends TestCase
         $this->assertFalse($this->review->canReview($normalFile));
     }
 
-    public function testReview(): void
+    /**
+     * @test
+     */
+    public function review(): void
     {
         $composerFile = Mockery::mock('GitReview\File\FileInterface');
         $composerFile->shouldReceive('getFullPath')->once()->andReturn('/some/path/composer.json');

--- a/tests/unit/Review/Composer/ComposerSecurityReviewTest.php
+++ b/tests/unit/Review/Composer/ComposerSecurityReviewTest.php
@@ -30,7 +30,10 @@ class ComposerSecurityReviewTest extends TestCase
         Mockery::close();
     }
 
-    public function testCanReview(): void
+    /**
+     * @test
+     */
+    public function can_review(): void
     {
         $composerFile = Mockery::mock('GitReview\File\FileInterface');
         $composerFile->shouldReceive('getFileName')->once()->andReturn('composer.lock');
@@ -43,7 +46,10 @@ class ComposerSecurityReviewTest extends TestCase
         $this->assertFalse($this->review->canReview($normalFile));
     }
 
-    public function testReview(): void
+    /**
+     * @test
+     */
+    public function review(): void
     {
         $composerFile = Mockery::mock('GitReview\File\FileInterface');
         $composerFile->shouldReceive('getFullPath')->once()->andReturn('/some/path/composer.lock');

--- a/tests/unit/Review/General/LineEndingsReviewTest.php
+++ b/tests/unit/Review/General/LineEndingsReviewTest.php
@@ -33,14 +33,20 @@ class LineEndingsReviewTest extends TestCase
         Mockery::close();
     }
 
-    public function testCanReview(): void
+    /**
+     * @test
+     */
+    public function can_review(): void
     {
         $this->file->shouldReceive('getMimeType')->once()->andReturn('text');
 
         $this->assertTrue($this->review->canReview($this->file));
     }
 
-    public function testReview(): void
+    /**
+     * @test
+     */
+    public function review(): void
     {
         $this->file->shouldReceive('getFullPath')->once()->andReturn(__FILE__);
 

--- a/tests/unit/Review/General/NoCommitTagReviewTest.php
+++ b/tests/unit/Review/General/NoCommitTagReviewTest.php
@@ -33,14 +33,20 @@ class NoCommitTagReviewTest extends TestCase
         Mockery::close();
     }
 
-    public function testCanReview(): void
+    /**
+     * @test
+     */
+    public function can_review(): void
     {
         $this->file->shouldReceive('getMimeType')->once()->andReturn('text');
 
         $this->assertTrue($this->review->canReview($this->file));
     }
 
-    public function testReview(): void
+    /**
+     * @test
+     */
+    public function review(): void
     {
         $this->file->shouldReceive('getFullPath')->once()->andReturn(__FILE__);
 

--- a/tests/unit/Review/PHP/PhpCodeSnifferReviewTest.php
+++ b/tests/unit/Review/PHP/PhpCodeSnifferReviewTest.php
@@ -33,21 +33,30 @@ class PhpCodeSnifferReviewTest extends TestCase
         Mockery::close();
     }
 
-    public function testGetOption(): void
+    /**
+     * @test
+     */
+    public function get_option(): void
     {
         $this->review->setOption('standard', 'PSR2');
 
         $this->assertSame('PSR2', $this->review->getOption('standard'));
     }
 
-    public function testGetOptionForConsole(): void
+    /**
+     * @test
+     */
+    public function get_option_for_console(): void
     {
         $this->review->setOption('standard', 'PSR2');
 
         $this->assertSame('--standard=PSR2 ', $this->review->getOptionsForConsole());
     }
 
-    public function testSetOption(): void
+    /**
+     * @test
+     */
+    public function set_option(): void
     {
         $this->review->setOption('standard', 'PSR2');
 
@@ -60,13 +69,18 @@ class PhpCodeSnifferReviewTest extends TestCase
 
     /**
      * @expectedException RuntimeException
+     *
+     * @test
      */
-    public function testSetOptionWithReportOption(): void
+    public function set_option_with_report_option(): void
     {
         $this->review->setOption('report', 'value');
     }
 
-    public function testSetOptionWithOverwrite(): void
+    /**
+     * @test
+     */
+    public function set_option_with_overwrite(): void
     {
         $this->review->setOption('standard', 'PSR2');
 
@@ -77,26 +91,38 @@ class PhpCodeSnifferReviewTest extends TestCase
         $this->assertSame('PEAR', $this->review->getOption('standard'));
     }
 
-    public function testSetOptionReturnsReview(): void
+    /**
+     * @test
+     */
+    public function set_option_returns_review(): void
     {
         $this->assertInstanceOf(\get_class($this->review), $this->review->setOption('test', 'test'));
     }
 
-    public function testCanReview(): void
+    /**
+     * @test
+     */
+    public function can_review(): void
     {
         $this->file->shouldReceive('getExtension')->once()->andReturn('php');
 
         $this->assertTrue($this->review->canReview($this->file));
     }
 
-    public function testCanReviewWithInvalidExtension(): void
+    /**
+     * @test
+     */
+    public function can_review_with_invalid_extension(): void
     {
         $this->file->shouldReceive('getExtension')->once()->andReturn('txt');
 
         $this->assertFalse($this->review->canReview($this->file));
     }
 
-    public function testReviewWithPsr2Standard(): void
+    /**
+     * @test
+     */
+    public function review_with_psr2_standard(): void
     {
         $this->file->shouldReceive('getFullPath')->once()->andReturn(__FILE__);
 
@@ -117,7 +143,10 @@ class PhpCodeSnifferReviewTest extends TestCase
         $this->assertNull($this->review->review($reporter, $this->file));
     }
 
-    public function testReviewWithViolations(): void
+    /**
+     * @test
+     */
+    public function review_with_violations(): void
     {
         $this->file->shouldReceive('getFullPath')->once()->andReturn(__FILE__);
 

--- a/tests/unit/Review/PHP/PhpLeadingLineReviewTest.php
+++ b/tests/unit/Review/PHP/PhpLeadingLineReviewTest.php
@@ -33,21 +33,30 @@ class PhpLeadingLineReviewTest extends TestCase
         Mockery::close();
     }
 
-    public function testCanReview(): void
+    /**
+     * @test
+     */
+    public function can_review(): void
     {
         $this->file->shouldReceive('getExtension')->once()->andReturn('php');
 
         $this->assertTrue($this->review->canReview($this->file));
     }
 
-    public function testCanReviewWithInvalidExtension(): void
+    /**
+     * @test
+     */
+    public function can_review_with_invalid_extension(): void
     {
         $this->file->shouldReceive('getExtension')->once()->andReturn('txt');
 
         $this->assertFalse($this->review->canReview($this->file));
     }
 
-    public function testReviewWithBadBeginning(): void
+    /**
+     * @test
+     */
+    public function review_with_bad_beginning(): void
     {
         $this->file->shouldReceive('getFullPath')->once()->andReturn(__FILE__);
 
@@ -63,7 +72,10 @@ class PhpLeadingLineReviewTest extends TestCase
         $this->assertNull($this->review->review($reporter, $this->file));
     }
 
-    public function testReviewWithDefaultBeginning(): void
+    /**
+     * @test
+     */
+    public function review_with_default_beginning(): void
     {
         $this->file->shouldReceive('getFullPath')->once()->andReturn(__FILE__);
 
@@ -78,7 +90,10 @@ class PhpLeadingLineReviewTest extends TestCase
         $this->assertNull($this->review->review($reporter, $this->file));
     }
 
-    public function testReviewWithScriptBeginning(): void
+    /**
+     * @test
+     */
+    public function review_with_script_beginning(): void
     {
         $this->file->shouldReceive('getFullPath')->once()->andReturn(__FILE__);
 

--- a/tests/unit/Review/PHP/PhpLintReviewTest.php
+++ b/tests/unit/Review/PHP/PhpLintReviewTest.php
@@ -33,28 +33,40 @@ class PhpLintReviewTest extends TestCase
         Mockery::close();
     }
 
-    public function testCanReviewWithPhpExtension(): void
+    /**
+     * @test
+     */
+    public function can_review_with_php_extension(): void
     {
         $this->file->shouldReceive('getExtension')->once()->andReturn('php');
 
         $this->assertTrue($this->review->canReview($this->file));
     }
 
-    public function testCanReviewWithPhtmlExtension(): void
+    /**
+     * @test
+     */
+    public function can_review_with_phtml_extension(): void
     {
         $this->file->shouldReceive('getExtension')->once()->andReturn('phtml');
 
         $this->assertTrue($this->review->canReview($this->file));
     }
 
-    public function testCanReviewWithInvalidExtension(): void
+    /**
+     * @test
+     */
+    public function can_review_with_invalid_extension(): void
     {
         $this->file->shouldReceive('getExtension')->once()->andReturn('txt');
 
         $this->assertFalse($this->review->canReview($this->file));
     }
 
-    public function testReview(): void
+    /**
+     * @test
+     */
+    public function review(): void
     {
         $this->file->shouldReceive('getFullPath')->twice()->andReturn(__FILE__);
 


### PR DESCRIPTION
The aim of this PR is to ensure the project follows the following:

1. Tests should ideally have `@test` annotations and the method names should be `snake_case`
2. Exlcude PHP-Fig camel case method names, this allows point 1 of this PR to be allowed
3. Exclude PHP-Fig suggested max line length on the `tests/*` folder, this will allow for expressive test names

As part of this PR, tests have been converted from `camelCase` to `snakeCase`.

Unfortunately, the `php_unit_test_annotation` rule only adds the `@test` annotation and doesnt convert the method name to snake case, as the config suggests.